### PR TITLE
Added support for GPT-4o #7

### DIFF
--- a/src/api/providers/openai.json
+++ b/src/api/providers/openai.json
@@ -18,5 +18,9 @@
 	"gpt-3.5-turbo-instruct": {
 		"inputCost": 1.5,
 		"outputCost": 2
+	},
+	"gpt-4o": {
+		"inputCost": 5,
+		"outputCost": 15
 	}
 }

--- a/src/api/providers/openrouter.json
+++ b/src/api/providers/openrouter.json
@@ -179,6 +179,10 @@
 		"inputCost": 0.003,
 		"outputCost": 0.004
 	},
+	"openai/gpt-4o": {
+		"inputCost": 0.005,
+		"outputCost": 0.015
+	},
 	"openai/gpt-4-turbo": {
 		"inputCost": 0.01,
 		"outputCost": 0.03

--- a/src/settings/versions/1.1.0/api/openai.ts
+++ b/src/settings/versions/1.1.0/api/openai.ts
@@ -5,6 +5,7 @@ export const COMPLETIONS_MODELS = [
 ] as const;
 
 export const CHAT_COMPLETIONS_MODELS = [
+	'gpt-4o',
 	'gpt-4-0125-preview',
 	'gpt-4-turbo-preview',
 	'gpt-4-1106-preview',
@@ -32,6 +33,7 @@ export const MODEL_INPUT_COSTS: Record<
 	'gpt-3.5-turbo-instruct': 1.5,
 	'davinci-002': 12.0,
 	'babbage-002': 1.6,
+	'gpt-4o': 5.0,
 	'gpt-4-0125-preview': 10.0,
 	'gpt-4-turbo-preview': 10.0,
 	'gpt-4-1106-preview': 10.0,
@@ -59,6 +61,7 @@ export const MODEL_OUTPUT_COSTS: Record<
 	'gpt-3.5-turbo-instruct': 2.0,
 	'davinci-002': 12.0,
 	'babbage-002': 1.6,
+	'gpt-4o': 15,
 	'gpt-4-0125-preview': 30,
 	'gpt-4-turbo-preview': 30,
 	'gpt-4-1106-preview': 30,

--- a/src/settings/versions/1.2.0/api/providers/openai.json
+++ b/src/settings/versions/1.2.0/api/providers/openai.json
@@ -1,4 +1,8 @@
 {
+	"gpt-4o": {
+		"inputCost": 5,
+		"outputCost": 15
+	},
 	"gpt-4-turbo": {
 		"inputCost": 10,
 		"outputCost": 30

--- a/src/settings/versions/1.2.0/api/providers/openrouter.json
+++ b/src/settings/versions/1.2.0/api/providers/openrouter.json
@@ -179,6 +179,10 @@
 		"inputCost": 0.003,
 		"outputCost": 0.004
 	},
+	"openai/gpt-4o": {
+		"inputCost": 0.005,
+		"outputCost": 0.015
+	},
 	"openai/gpt-4-turbo": {
 		"inputCost": 0.01,
 		"outputCost": 0.03


### PR DESCRIPTION
Fixes #7 

Added OpenAI's latest model, GPT-4o, with an input cost of 5$ and an output cost of $15.
